### PR TITLE
BT vario support, secondary alt + other fixes

### DIFF
--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -44,6 +44,7 @@ public class Statics {
     public static final String PREFHEIGTHUNIT = "/com/pulce/wristglider/prefheightunit";
     public static final String PREFSPEEDUNIT = "/com/pulce/wristglider/prefspeedunit";
     public static final String PREFUSEBTVARIO = "/com/pulce/wristglider/prefusebtvario";
+    public static final String PREFBTVARIOUNIT = "/com/pulce/wristglider/prefbtvariounit";
     public static final String PREFBTVARIODEVICE = "/com/pulce/wristglider/prefbtvariodevice";
 
 

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -12,9 +12,7 @@ public class Statics {
     public static final int MY_PERMISSION_WRITE_STORAGE = 42;
     public static final int MY_PERMISSION_FINE_LOCATION = 43;
 
-    public static final int MY_REQUEST_CONNECT_DEVICE_SECURE = 1;
-    public static final int MY_REQUEST_CONNECT_DEVICE_INSECURE = 2;
-    public static final int MY_REQUEST_ENABLE_BT = 3;
+    public static final int MY_REQUEST_ENABLE_BT = 1;
 
     public static final int MY_BT_FAILED_NO_BT = 1;
     public static final int MY_BT_FAILED_NO_DEVICE = 2;

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -12,6 +12,17 @@ public class Statics {
     public static final int MY_PERMISSION_WRITE_STORAGE = 42;
     public static final int MY_PERMISSION_FINE_LOCATION = 43;
 
+    public static final int MY_REQUEST_CONNECT_DEVICE_SECURE = 1;
+    public static final int MY_REQUEST_CONNECT_DEVICE_INSECURE = 2;
+    public static final int MY_REQUEST_ENABLE_BT = 3;
+
+    public static final int MY_BT_FAILED_NO_BT = 1;
+    public static final int MY_BT_FAILED_NO_DEVICE = 2;
+    public static final int MY_BT_FAILED_USER = 3;
+
+    public static final int MY_BT_MESSAGE_READ = 0;
+    public static final int MY_BT_MESSAGE_WRITE = 1;
+
     private static final DecimalFormat latForm = new DecimalFormat("0000000");
     private static final DecimalFormat lonForm = new DecimalFormat("00000000");
 
@@ -19,6 +30,7 @@ public class Statics {
     public static final String DATAIGC = "/com/pulce/wristglider/dataigc";
     public static final String DATADELETE = "/com/pulce/wristglider/datadelete";
     public static final String DATATHROWABLE = "/com/pulce/wristglider/datathrowable";
+    public static final String DATABTFAILED = "/com/pulce/wristglider/databtfailed";
 
     public static final String PREFPILOTNAME = "/com/pulce/wristglider/prefpilotname";
     public static final String PREFGLIDERTYPE = "/com/pulce/wristglider/glidertype";

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -31,6 +31,8 @@ public class Statics {
     public static final String PREFSCREENON = "/com/pulce/wristglider/prefscreenon";
     public static final String PREFHEIGTHUNIT = "/com/pulce/wristglider/prefheightunit";
     public static final String PREFSPEEDUNIT = "/com/pulce/wristglider/prefspeedunit";
+    public static final String PREFUSEBTVARIO = "/com/pulce/wristglider/prefusebtvario";
+    public static final String PREFBTVARIODEVICE = "/com/pulce/wristglider/prefbtvariodevice";
 
 
     public static String getUTCdateReverse() {

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -21,6 +21,8 @@ public class Statics {
     public static final int MY_BT_MESSAGE_READ = 0;
     public static final int MY_BT_MESSAGE_WRITE = 1;
 
+    public static final int MY_NULL_VALUE = -999999;
+
     private static final DecimalFormat latForm = new DecimalFormat("0000000");
     private static final DecimalFormat lonForm = new DecimalFormat("00000000");
 

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -77,6 +77,8 @@ public class MainActivity extends Activity implements
     private GoogleApiClient mGoogleApiClient;
     private TableLayout tablelayout;
 
+    private CheckBox checkBoxBT;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -114,6 +116,7 @@ public class MainActivity extends Activity implements
     @Override
     public void onPause() {
         super.onPause();
+        Wearable.DataApi.removeListener(mGoogleApiClient, this);
     }
 
     @Override
@@ -135,6 +138,10 @@ public class MainActivity extends Activity implements
             if (event.getType() == DataEvent.TYPE_CHANGED &&
                     event.getDataItem().getUri().getPath().contains(Statics.DATATHROWABLE)) {
                 getExceptionFromWear(event.getDataItem());
+            }
+            if (event.getType() == DataEvent.TYPE_CHANGED &&
+                    event.getDataItem().getUri().getPath().contains(Statics.DATABTFAILED)) {
+                getBTFailed(event.getDataItem());
             }
         }
     }
@@ -190,6 +197,9 @@ public class MainActivity extends Activity implements
                         }
                         if (item.getUri().getPath().contains(Statics.DATATHROWABLE)) {
                             getExceptionFromWear(item);
+                        }
+                        if (item.getUri().getPath().contains(Statics.DATABTFAILED)) {
+                            getBTFailed(item);
                         }
                     }
                 }
@@ -463,6 +473,7 @@ public class MainActivity extends Activity implements
                     }
                 });
                 tr.addView(cp2);
+                if (preferencekey.equals(Statics.PREFUSEBTVARIO)) checkBoxBT = cp2;
                 break;
             case Statics.PREFHEIGTHUNIT:
             case Statics.PREFSPEEDUNIT:
@@ -584,4 +595,14 @@ public class MainActivity extends Activity implements
         }
     }
 
+    private void getBTFailed(DataItem dataItem) {
+        dataItem.freeze();
+        final Uri dataItemUri = dataItem.getUri();
+        DataMapItem dataMapItem = DataMapItem.fromDataItem(dataItem);
+        final int reason = dataMapItem.getDataMap().getInt("reason");
+        Wearable.DataApi.deleteDataItems(mGoogleApiClient, dataItemUri);
+        prefs.edit().putBoolean(Statics.PREFUSEBTVARIO, false).apply();
+        checkBoxBT.setChecked(false);
+        if (debugMode) Log.d(TAG, "BT failed on wear, reason: " + reason);
+    }
 }

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -104,12 +104,12 @@ public class MainActivity extends Activity implements
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(this)
                 .addApi(Wearable.API).build();
-        mGoogleApiClient.connect();
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        mGoogleApiClient.connect();
     }
 
 
@@ -117,6 +117,7 @@ public class MainActivity extends Activity implements
     public void onPause() {
         super.onPause();
         Wearable.DataApi.removeListener(mGoogleApiClient, this);
+        mGoogleApiClient.disconnect();
     }
 
     @Override
@@ -600,9 +601,20 @@ public class MainActivity extends Activity implements
         final Uri dataItemUri = dataItem.getUri();
         DataMapItem dataMapItem = DataMapItem.fromDataItem(dataItem);
         final int reason = dataMapItem.getDataMap().getInt("reason");
+        if (debugMode) Log.d(TAG, "BT failed on wear, reason: " + reason);
+        switch (reason) {
+            case Statics.MY_BT_FAILED_NO_BT:
+                Toast.makeText(getApplicationContext(), R.string.bt_failed_no_bt, Toast.LENGTH_LONG).show();
+                break;
+            case Statics.MY_BT_FAILED_NO_DEVICE:
+                Toast.makeText(getApplicationContext(), R.string.bt_failed_no_device, Toast.LENGTH_LONG).show();
+                break;
+            case Statics.MY_BT_FAILED_USER:
+                Toast.makeText(getApplicationContext(), R.string.bt_failed_user, Toast.LENGTH_LONG).show();
+                break;
+        }
         Wearable.DataApi.deleteDataItems(mGoogleApiClient, dataItemUri);
         prefs.edit().putBoolean(Statics.PREFUSEBTVARIO, false).apply();
         checkBoxBT.setChecked(false);
-        if (debugMode) Log.d(TAG, "BT failed on wear, reason: " + reason);
     }
 }

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -384,7 +384,7 @@ public class MainActivity extends Activity implements
                             layout.addView(gliderType);
                             layout.addView(gliderID);
                             builder.setView(layout);
-                            builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                            builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int whichButton) {
                                     spinnerSilent = true;
                                     spinnerArray.add(0, gliderType.getText().toString() + "\n" + gliderID.getText().toString());
@@ -396,7 +396,7 @@ public class MainActivity extends Activity implements
                                     updatePreferences();
                                 }
                             });
-                            builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                            builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int whichButton) {
                                     spinnerSilent = true;
                                     spinner.setSelection(spinner.lastActivePosition);
@@ -555,7 +555,7 @@ public class MainActivity extends Activity implements
                         input.setText(prefs.getString(preferencekey, ""));
                         input.setInputType(InputType.TYPE_CLASS_TEXT);
                         builder.setView(input);
-                        builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+                        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 tv2.setText(input.getText().toString());
@@ -566,7 +566,7 @@ public class MainActivity extends Activity implements
                                 if (debugMode) Log.d(TAG, "Updating Preferences");
                             }
                         });
-                        builder.setNegativeButton(getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                        builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 dialog.cancel();

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -472,6 +472,7 @@ public class MainActivity extends Activity implements
                         spinner2Array.add("0");
                         spinner2Array.add("90");
                         spinner2Array.add("-90");
+                        spinner2Array.add("AUTO");
                         break;
                     case Statics.PREFHEIGTHUNIT:
                         spinner2Array.add("m");

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -100,6 +100,7 @@ public class MainActivity extends Activity implements
         addTableRow(getString(R.string.height_unit), Statics.PREFHEIGTHUNIT);
         addTableRow(getString(R.string.speed_unit), Statics.PREFSPEEDUNIT);
         addTableRow(getString(R.string.use_bt_vario), Statics.PREFUSEBTVARIO);
+        addTableRow(getString(R.string.vario_unit), Statics.PREFBTVARIOUNIT);
 
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(this)
@@ -314,6 +315,7 @@ public class MainActivity extends Activity implements
         dataMap.getDataMap().putString(Statics.PREFHEIGTHUNIT, prefs.getString(Statics.PREFHEIGTHUNIT, "m"));
         dataMap.getDataMap().putString(Statics.PREFROTATEDEGREES, prefs.getString(Statics.PREFROTATEDEGREES, "0"));
         dataMap.getDataMap().putBoolean(Statics.PREFUSEBTVARIO, prefs.getBoolean(Statics.PREFUSEBTVARIO, false));
+        dataMap.getDataMap().putString(Statics.PREFBTVARIOUNIT, prefs.getString(Statics.PREFBTVARIOUNIT, "m/s"));
         PutDataRequest request = dataMap.asPutDataRequest();
         request.setUrgent();
         Wearable.DataApi.putDataItem(mGoogleApiClient, request);
@@ -478,6 +480,7 @@ public class MainActivity extends Activity implements
                 break;
             case Statics.PREFHEIGTHUNIT:
             case Statics.PREFSPEEDUNIT:
+            case Statics.PREFBTVARIOUNIT:
             case Statics.PREFLOGGERSECONDS:
             case Statics.PREFROTATEDEGREES:
                 final Spinner spinner2 = new Spinner(this);
@@ -495,6 +498,10 @@ public class MainActivity extends Activity implements
                     case Statics.PREFSPEEDUNIT:
                         spinner2Array.add("km/h");
                         spinner2Array.add("mph");
+                        spinner2Array.add("kn");
+                        break;
+                    case Statics.PREFBTVARIOUNIT:
+                        spinner2Array.add("m/s");
                         spinner2Array.add("kn");
                         break;
                     default:

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -97,6 +97,7 @@ public class MainActivity extends Activity implements
         addTableRow(getString(R.string.rotate_view), Statics.PREFROTATEDEGREES);
         addTableRow(getString(R.string.height_unit), Statics.PREFHEIGTHUNIT);
         addTableRow(getString(R.string.speed_unit), Statics.PREFSPEEDUNIT);
+        addTableRow(getString(R.string.use_bt_vario), Statics.PREFUSEBTVARIO);
 
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(this)
@@ -301,6 +302,7 @@ public class MainActivity extends Activity implements
         dataMap.getDataMap().putString(Statics.PREFSPEEDUNIT, prefs.getString(Statics.PREFSPEEDUNIT, "km/h"));
         dataMap.getDataMap().putString(Statics.PREFHEIGTHUNIT, prefs.getString(Statics.PREFHEIGTHUNIT, "m"));
         dataMap.getDataMap().putString(Statics.PREFROTATEDEGREES, prefs.getString(Statics.PREFROTATEDEGREES, "0"));
+        dataMap.getDataMap().putBoolean(Statics.PREFUSEBTVARIO, prefs.getBoolean(Statics.PREFUSEBTVARIO, false));
         PutDataRequest request = dataMap.asPutDataRequest();
         request.setUrgent();
         Wearable.DataApi.putDataItem(mGoogleApiClient, request);
@@ -450,6 +452,7 @@ public class MainActivity extends Activity implements
                 break;
             case Statics.PREFLOGGERAUTO:
             case Statics.PREFSCREENON:
+            case Statics.PREFUSEBTVARIO:
                 final CheckBox cp2 = new CheckBox(this);
                 cp2.setChecked(prefs.getBoolean(preferencekey, false));
                 cp2.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -22,4 +22,7 @@
     <string name="enter_pilot">Pilot eingeben</string>
     <string name="saved_log">Speichere Log:</string>
     <string name="use_bt_vario">Use bluetooth vario</string>
+    <string name="bt_failed_no_bt">Your Wear device doesn\'t have Bluetooth adapter</string>
+    <string name="bt_failed_no_device">Bluetooth Vario device not found</string>
+    <string name="bt_failed_user">Bluetooth connection canceled by the user</string>
 </resources>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -21,4 +21,5 @@
     <string name="ok">Ok</string>
     <string name="enter_pilot">Pilot eingeben</string>
     <string name="saved_log">Speichere Log:</string>
+    <string name="use_bt_vario">Use bluetooth vario</string>
 </resources>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -17,12 +17,6 @@
     <string name="glider">Fluggerät</string>
     <string name="delete">Löschen</string>
     <string name="select">Auswählen</string>
-    <string name="cancel">Abbrechen</string>
-    <string name="ok">Ok</string>
     <string name="enter_pilot">Pilot eingeben</string>
     <string name="saved_log">Speichere Log:</string>
-    <string name="use_bt_vario">Use bluetooth vario</string>
-    <string name="bt_failed_no_bt">Your Wear device doesn\'t have Bluetooth adapter</string>
-    <string name="bt_failed_no_device">Bluetooth Vario device not found</string>
-    <string name="bt_failed_user">Bluetooth connection canceled by the user</string>
 </resources>

--- a/mobile/src/main/res/values-pl/strings.xml
+++ b/mobile/src/main/res/values-pl/strings.xml
@@ -23,4 +23,5 @@
     <string name="bt_failed_no_bt">Twój zegarek nie obsługuje Bluetooth</string>
     <string name="bt_failed_no_device">Brak urządzenia vario BT</string>
     <string name="bt_failed_user">Połączenie Bluetooth anulowane przez użytkownika</string>
+    <string name="vario_unit">Wariometr</string>
 </resources>

--- a/mobile/src/main/res/values-pl/strings.xml
+++ b/mobile/src/main/res/values-pl/strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Wristglider</string>
+    <string name="pilot_name">Pilot</string>
+    <string name="glider_type">Typ</string>
+    <string name="glider_id">ID</string>
+    <string name="permission_external_storage_hint">Uprawnienie zapisu do pamięci zewnętrznej jest wymagane by zapisać pliki .igc</string>
+    <string name="height_unit">Wysokość</string>
+    <string name="logger_autostart">Auto logowanie</string>
+    <string name="logger_seconds">Częst. logowania</string>
+    <string name="enable_ambient">Przyciemnianie</string>
+    <string name="rotate_view">Obrót ekranu</string>
+    <string name="speed_unit">Prędkość</string>
+    <string name="add_new_glider1">Dodaj</string>
+    <string name="add_new_glider2">paralotnię...</string>
+    <string name="glider_type_and_id">Typ i ID paralotni</string>
+    <string name="glider">Paralotnia</string>
+    <string name="delete">Usuń</string>
+    <string name="select">Wybierz</string>
+    <string name="enter_pilot">Nazwa pilota</string>
+    <string name="saved_log">Zapisuje log:</string>
+    <string name="use_bt_vario">Użyj vario BT</string>
+    <string name="bt_failed_no_bt">Twój zegarek nie obsługuje Bluetooth</string>
+    <string name="bt_failed_no_device">Brak urządzenia vario BT</string>
+    <string name="bt_failed_user">Połączenie Bluetooth anulowane przez użytkownika</string>
+</resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="bt_failed_no_bt">Your Wear device doesn\'t have Bluetooth adapter</string>
     <string name="bt_failed_no_device">Bluetooth Vario device not found</string>
     <string name="bt_failed_user">Bluetooth connection canceled by the user</string>
+    <string name="vario_unit">Vario unit</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="cancel">Cancel</string>
     <string name="enter_pilot">Enter Pilot</string>
     <string name="saved_log">Saving log:</string>
+    <string name="use_bt_vario">Use bluetooth vario</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="enter_pilot">Enter Pilot</string>
     <string name="saved_log">Saving log:</string>
     <string name="use_bt_vario">Use bluetooth vario</string>
+    <string name="bt_failed_no_bt">Your Wear device doesn\'t have Bluetooth adapter</string>
+    <string name="bt_failed_no_device">Bluetooth Vario device not found</string>
+    <string name="bt_failed_user">Bluetooth connection canceled by the user</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -16,8 +16,6 @@
     <string name="glider">Glider</string>
     <string name="select">Select</string>
     <string name="delete">Delete</string>
-    <string name="ok">Ok</string>
-    <string name="cancel">Cancel</string>
     <string name="enter_pilot">Enter Pilot</string>
     <string name="saved_log">Saving log:</string>
     <string name="use_bt_vario">Use bluetooth vario</string>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <application
         android:allowBackup="true"

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-feature android:name="android.hardware.type.watch" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
 

--- a/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
+++ b/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
@@ -399,6 +399,7 @@ public class MainWearActivity extends WearableActivity implements
             }
         }
         prefs.edit().putString(Statics.PREFROTATEDEGREES, dataMapItem.getDataMap().getString(Statics.PREFROTATEDEGREES, "0")).apply();
+        prefs.edit().putBoolean(Statics.PREFUSEBTVARIO, dataMapItem.getDataMap().getBoolean(Statics.PREFUSEBTVARIO)).apply();
         setMultipliers();
         if (debugMode) Log.d(TAG, "Preferences updated");
     }

--- a/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
+++ b/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
@@ -153,6 +153,8 @@ public class MainWearActivity extends WearableActivity implements
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
         } else if (prefs.getString(Statics.PREFROTATEDEGREES, "0").equals("90")){
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        } else if (prefs.getString(Statics.PREFROTATEDEGREES, "0").equals("AUTO")){
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
         }
         if (DateFormat.is24HourFormat(this)) {
             clockFormat = new SimpleDateFormat("HH:mm");
@@ -394,6 +396,8 @@ public class MainWearActivity extends WearableActivity implements
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
             } else if (dataMapItem.getDataMap().getString(Statics.PREFROTATEDEGREES, "0").equals("90")){
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            } else if (dataMapItem.getDataMap().getString(Statics.PREFROTATEDEGREES, "0").equals("AUTO")){
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
             } else {
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
             }

--- a/wear/src/main/res/layout-notround/activity_wear_main.xml
+++ b/wear/src/main/res/layout-notround/activity_wear_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<android.support.wearable.view.SwipeDismissFrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -138,5 +138,4 @@
 
     </RelativeLayout>
 
-
-</RelativeLayout>
+</android.support.wearable.view.SwipeDismissFrameLayout>

--- a/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
+++ b/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    tools:context="com.pulce.wristglider.MainWearActivity"
+    tools:deviceIds="wear">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/black"
+        android:weightSum="5">
+
+        <LinearLayout
+            android:id="@+id/varioBar"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:layout_weight="1"
+            android:weightSum="20">
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar10"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="100%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar9"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="93%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar8"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="86%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar7"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="79%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar6"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="72%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar5"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="65%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar4"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="58%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar3"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="51%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar2"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="44%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar1"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="37%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_1"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="37%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_2"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="44%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_3"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="51%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_4"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="58%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_5"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="65%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_6"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="72%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_7"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="79%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_8"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="86%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_9"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="93%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_10"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="100%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:background="@color/black"
+            android:orientation="vertical"
+            android:fitsSystemWindows="true"
+            android:weightSum="2.02"
+            android:layout_weight="4">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/directionImage"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_centerVertical="true"
+                    android:background="@color/black"
+                    />
+
+                <ProgressBar
+                    android:id="@+id/progress"
+                    style="?android:attr/progressBarStyleSmall"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_centerVertical="true"
+                    android:indeterminate="true"
+                    android:indeterminateTintMode="src_atop"
+                    android:indeterminateTint="@color/white"
+                    android:visibility="visible"/>
+
+                <TextView
+                    android:id="@+id/speedtext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_marginEnd="5dp"
+                    android:layout_centerVertical="true"
+                    android:text="@string/hello_world"
+                    android:textColor="@color/white"
+                    android:textSize="52dp"
+                    android:includeFontPadding="false"/>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="0.02">
+
+                <View
+                    android:background="@color/white"
+                    android:layout_width = "80dp"
+                    android:layout_alignParentRight="true"
+                    android:layout_height="1dip"
+                    android:layout_centerVertical="true"/>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1">
+
+                <TextView
+                    android:id="@+id/otherfeed"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentBottom="true"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:layout_centerVertical="true"
+                    android:background="@color/black"
+                    android:text="@string/hello_world"
+                    android:textColor="@color/white"
+                    android:textSize="24dp"
+                    android:maxLines="2"
+                    android:includeFontPadding="false" />
+
+                <TextView
+                    android:id="@+id/altitext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_marginEnd="5dp"
+                    android:layout_centerVertical="true"
+                    android:background="@color/black"
+                    android:text="@string/hello_world"
+                    android:textColor="@color/white"
+                    android:textSize="52dp"
+                    android:includeFontPadding="false"/>
+
+            </RelativeLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/variominus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_marginStart="25dp"
+            android:layout_centerVertical="true"
+            android:text="-"
+            android:textColor="@color/white"
+            android:textSize="52dp"
+            android:includeFontPadding="false"
+            android:visibility="invisible"/>
+
+        <TextView
+            android:id="@+id/variotext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:text="@string/hello_world"
+            android:textColor="@color/white"
+            android:textSize="50dp"
+            android:includeFontPadding="false"
+            android:paddingRight="5dp"
+            android:layout_toRightOf="@id/variominus"/>
+
+        <TextView
+            android:id="@+id/loggerstate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginLeft="5dp"
+            android:background="@color/black"
+            android:text=""
+            android:textColor="@color/white"
+            android:textSize="14dp"
+            android:includeFontPadding="false"
+            android:layout_toRightOf="@id/variotext"/>
+
+        <TextView
+            android:id="@+id/batterystate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_alignParentEnd="true"
+            android:background="@color/black"
+            android:text=""
+            android:textColor="@color/white"
+            android:textSize="14dp"
+            android:includeFontPadding="false"/>
+
+    </RelativeLayout>
+
+
+</RelativeLayout>

--- a/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
+++ b/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<android.support.wearable.view.SwipeDismissFrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -352,8 +352,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
+                    android:layout_alignParentTop="true"
                     android:layout_marginEnd="5dp"
-                    android:layout_centerVertical="true"
+                    android:layout_marginTop="5dp"
                     android:text="@string/hello_world"
                     android:textColor="@color/white"
                     android:textSize="52dp"
@@ -401,8 +402,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
+                    android:layout_alignParentBottom="true"
                     android:layout_marginEnd="5dp"
-                    android:layout_centerVertical="true"
+                    android:layout_marginBottom="5dp"
                     android:background="@color/black"
                     android:text="@string/hello_world"
                     android:textColor="@color/white"
@@ -424,7 +426,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
-            android:layout_marginStart="25dp"
+            android:layout_marginStart="20dp"
             android:layout_centerVertical="true"
             android:text="-"
             android:textColor="@color/white"
@@ -472,5 +474,4 @@
 
     </RelativeLayout>
 
-
-</RelativeLayout>
+</android.support.wearable.view.SwipeDismissFrameLayout>

--- a/wear/src/main/res/layout-round/activity_wear_main.xml
+++ b/wear/src/main/res/layout-round/activity_wear_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.wearable.view.SwipeDismissFrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
@@ -150,5 +151,4 @@
 
     </LinearLayout>
 
-
-</RelativeLayout>
+</android.support.wearable.view.SwipeDismissFrameLayout>

--- a/wear/src/main/res/layout-round/activity_wear_main_vario.xml
+++ b/wear/src/main/res/layout-round/activity_wear_main_vario.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    tools:context="com.pulce.wristglider.MainWearActivity"
+    tools:deviceIds="wear"
+    >
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/black"
+        android:orientation="vertical"
+        android:fitsSystemWindows="true"
+        android:weightSum="3.04">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+            <ImageView
+                android:id="@+id/directionImage"
+                android:layout_width="55dp"
+                android:layout_height="55dp"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:background="@color/black"
+                />
+
+            <ProgressBar
+                android:id="@+id/progress"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="55dp"
+                android:layout_height="55dp"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:indeterminate="true"
+                android:indeterminateTintMode="src_atop"
+                android:indeterminateTint="@color/white"
+                android:visibility="visible"/>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="0.02">
+            <View
+                android:background="@color/white"
+                android:layout_width = "fill_parent"
+                android:layout_height="1dip"
+                android:layout_centerVertical="true"
+                />
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/altitext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="5dp"
+                android:background="@color/black"
+                android:text="--"
+                android:textColor="@color/white"
+                android:textSize="56dp"
+                android:includeFontPadding="false"/>
+
+            <TextView
+                android:id="@+id/otherfeed"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="5dp"
+                android:background="@color/black"
+                android:text="@string/hello_world"
+                android:textColor="@color/white"
+                android:textSize="30dp"
+                android:maxLines="2"
+                android:includeFontPadding="false"/>
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="0.02">
+
+            <View
+                android:background="@color/white"
+                android:layout_width = "fill_parent"
+                android:layout_height="1dip"
+                android:layout_centerVertical="true"/>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+            <TextView
+                android:id="@+id/speedtext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:background="@color/black"
+                android:text="--"
+                android:textColor="@color/white"
+                android:textSize="56dp"
+                android:includeFontPadding="false"/>
+        </RelativeLayout>
+
+
+    </LinearLayout>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:fitsSystemWindows="true"
+        android:weightSum="3">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="2">
+
+            <TextView
+                android:id="@+id/loggerstate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_centerHorizontal="true"
+                android:background="@color/black"
+                android:text=""
+                android:textColor="@color/white"
+                android:textSize="12dp"
+                android:includeFontPadding="false"/>
+
+         </RelativeLayout>
+
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/wear/src/main/res/layout-round/activity_wear_main_vario.xml
+++ b/wear/src/main/res/layout-round/activity_wear_main_vario.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.wearable.view.SwipeDismissFrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
@@ -22,26 +23,63 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1">
-            <ImageView
-                android:id="@+id/directionImage"
-                android:layout_width="55dp"
-                android:layout_height="55dp"
-                android:layout_centerHorizontal="true"
-                android:layout_centerVertical="true"
-                android:background="@color/black"
-                />
 
-            <ProgressBar
-                android:id="@+id/progress"
-                style="?android:attr/progressBarStyleSmall"
-                android:layout_width="55dp"
-                android:layout_height="55dp"
-                android:layout_centerHorizontal="true"
-                android:layout_centerVertical="true"
-                android:indeterminate="true"
-                android:indeterminateTintMode="src_atop"
-                android:indeterminateTint="@color/white"
-                android:visibility="visible"/>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:weightSum="100">
+
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="58">
+
+                    <ImageView
+                        android:id="@+id/directionImage"
+                        android:layout_width="50dp"
+                        android:layout_height="50dp"
+                        android:layout_alignParentRight="true"
+                        android:layout_centerVertical="true"
+                        android:background="@color/black"
+                        />
+
+                    <ProgressBar
+                        android:id="@+id/progress"
+                        style="?android:attr/progressBarStyleSmall"
+                        android:layout_width="50dp"
+                        android:layout_height="50dp"
+                        android:layout_alignParentRight="true"
+                        android:layout_centerVertical="true"
+                        android:indeterminate="true"
+                        android:indeterminateTintMode="src_atop"
+                        android:indeterminateTint="@color/white"
+                        android:visibility="visible"/>
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="42">
+
+                    <TextView
+                        android:id="@+id/otherfeed"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@color/black"
+                        android:text="@string/hello_world"
+                        android:textColor="@color/white"
+                        android:textSize="24dp"
+                        android:maxLines="2"
+                        android:includeFontPadding="false"
+                        android:layout_alignParentLeft="true"
+                        android:layout_alignParentBottom="true"
+                        android:layout_marginBottom="2dp"
+                        android:layout_marginLeft="5dp"/>
+
+                </RelativeLayout>
+
+            </LinearLayout>
 
         </RelativeLayout>
 
@@ -63,20 +101,30 @@
             android:layout_weight="1">
 
             <TextView
-                android:id="@+id/altitext"
+                android:id="@+id/variominus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
+                android:layout_marginStart="20dp"
                 android:layout_centerVertical="true"
-                android:layout_marginStart="5dp"
-                android:background="@color/black"
-                android:text="--"
+                android:text="-"
                 android:textColor="@color/white"
-                android:textSize="56dp"
+                android:textSize="48dp"
                 android:includeFontPadding="false"/>
 
             <TextView
-                android:id="@+id/otherfeed"
+                android:id="@+id/variotext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:text="@string/hello_world"
+                android:textColor="@color/white"
+                android:textSize="45dp"
+                android:includeFontPadding="false"
+                android:layout_toRightOf="@id/variominus"/>
+
+            <TextView
+                android:id="@+id/altitext"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
@@ -85,9 +133,9 @@
                 android:background="@color/black"
                 android:text="@string/hello_world"
                 android:textColor="@color/white"
-                android:textSize="30dp"
-                android:maxLines="2"
+                android:textSize="45dp"
                 android:includeFontPadding="false"/>
+
         </RelativeLayout>
 
         <RelativeLayout
@@ -99,7 +147,7 @@
                 android:background="@color/white"
                 android:layout_width = "fill_parent"
                 android:layout_height="1dip"
-                android:layout_centerVertical="true"/>
+                android:layout_centerVertical="true" />
 
         </RelativeLayout>
 
@@ -115,7 +163,7 @@
                 android:background="@color/black"
                 android:text="--"
                 android:textColor="@color/white"
-                android:textSize="56dp"
+                android:textSize="50dp"
                 android:includeFontPadding="false"/>
         </RelativeLayout>
 
@@ -128,6 +176,12 @@
         android:orientation="vertical"
         android:fitsSystemWindows="true"
         android:weightSum="3">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+        </RelativeLayout>
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -150,5 +204,303 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:weightSum="2">
 
-</RelativeLayout>
+        <LinearLayout
+            android:id="@+id/varioBar"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:layout_weight="1"
+            android:weightSum="20">
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar10"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="90%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar9"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="70%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar8"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="55%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar7"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="45%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar6"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="35%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar5"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="29%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar4"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="23%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar3"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="19%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar2"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="15%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginBottom="1dp"
+                android:layout_marginTop="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar1"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="13%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginBottom="1dp"
+                android:layout_marginTop="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_1"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="13%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_2"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="15%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_3"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="19%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_4"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="23%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_5"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="29%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_6"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="35%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_7"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="45%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_8"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="55%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_9"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="70%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+            <android.support.percent.PercentRelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_margin="1dp"
+                android:layout_weight="1">
+
+                <View
+                    android:id="@+id/varioBar_10"
+                    android:background="@color/white"
+                    android:layout_height="match_parent"
+                    app:layout_widthPercent="90%"/>
+
+            </android.support.percent.PercentRelativeLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</android.support.wearable.view.SwipeDismissFrameLayout>

--- a/wear/src/main/res/values-de/strings.xml
+++ b/wear/src/main/res/values-de/strings.xml
@@ -6,5 +6,4 @@
     <string name="stop_logger_confirm">Möchtest Du den Logger stoppen?</string>
     <string name="stop_logger">Logger Stoppen</string>
     <string name="logger_started">Flug gestartet</string>
-    <string name="choose_bt_device">Select BT Vario</string>
 </resources>

--- a/wear/src/main/res/values-de/strings.xml
+++ b/wear/src/main/res/values-de/strings.xml
@@ -6,4 +6,5 @@
     <string name="stop_logger_confirm">Möchtest Du den Logger stoppen?</string>
     <string name="stop_logger">Logger Stoppen</string>
     <string name="logger_started">Flug gestartet</string>
+    <string name="choose_bt_device">Select BT Vario</string>
 </resources>

--- a/wear/src/main/res/values-pl/strings.xml
+++ b/wear/src/main/res/values-pl/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Wristglider</string>
+    <string name="permission_fine_location_hint">Aplikacja wymaga uprawnienia do lokalizacji!</string>
+    <string name="stop_logger">Zatrzymanie logowania</string>
+    <string name="stop_logger_confirm">Czy na pewno chcesz zatrzymać logowanie?</string>
+    <string name="logger_started">Lot rozpoczęty</string>
+    <string name="flight_time">Czas lotu:</string>
+    <string name="choose_bt_device">Wybierz vario BT</string>
+    <string name="bt_disconnect">Bluetooth rozłączony</string>
+    <string name="bt_connecting">Łączenie z Bluetooth...</string>
+    <string name="bt_connected">Bluetooth połączony</string>
+    <string name="bt_connection_failed">Nieudane połączenie Bluetooth</string>
+    <string name="bt_connection_lost">Utracono połączenie Bluetooth</string>
+</resources>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
     <string name="logger_started">Flight started</string>
     <string name="flight_time">Flight time:</string>
     <string name="choose_bt_device">Select BT Vario</string>
+    <string name="bt_disconnect">Bluetooth disconnected</string>
+    <string name="bt_connecting">Bluetooth connecting...</string>
+    <string name="bt_connected">Bluetooth connected</string>
+    <string name="bt_connection_failed">Bluetooth connection failed</string>
+    <string name="bt_connection_lost">Bluetooth connection lost</string>
 </resources>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="stop_logger_confirm">Sure you want to stop logger?</string>
     <string name="logger_started">Flight started</string>
     <string name="flight_time">Flight time:</string>
+    <string name="choose_bt_device">Select BT Vario</string>
 </resources>


### PR DESCRIPTION
Changes:

* Added support for automatic orientation from watch sensor
* DataApi fixes (on activity pausing/stoping/resuming)
* Added bluetooth vario support (generic NMEA PTAS1 and LK8EX1 protocol)
* Added polish translation and some little localization changes
* Added new layout with vario support
* Dynamically switching layouts based on Use BT vario option (old layout is untouched)
* Added vario unit setting
* Added AGL height support (based on GPS or Vario alt if available) - to reset AGL - triple tap, double tap to switch between AGL and ASL
* Disabled swipe to dismiss gesture

Demo movie:
https://www.youtube.com/watch?v=Pcapo8sdPPQ

Screenshots from new vario layouts (default layouts I have leaved without visual changes):

![screenshot_1511639364](https://user-images.githubusercontent.com/20594810/33244702-80d1c872-d2fc-11e7-92c3-4ab7bd38b98f.png)
![screenshot_1511685356](https://user-images.githubusercontent.com/20594810/33244704-83d636ca-d2fc-11e7-9899-2893790fbbbc.png)

