### PR TITLE
Watch barometer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.2.0'
@@ -19,13 +19,13 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     project.ext {
         myApplicationID="com.pulce.wristglider"
-        myVersionCode=26
-        myVersionNumber="0.4.7"
+        myVersionCode=27
+        myVersionNumber="0.4.8"
         myMinSdkVersion=21
         myWearMinSdkVersion=23
         myTargetSdkVersion=28

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,11 @@ allprojects {
     repositories {
         mavenCentral()
         google()
+        maven { url "https://jitpack.io" }
     }
     project.ext {
         myApplicationID="com.pulce.wristglider"
-        myVersionCode=28
+        myVersionCode=29
         myVersionNumber="0.4.8"
         myMinSdkVersion=21
         myWearMinSdkVersion=23

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     }
     project.ext {
         myApplicationID="com.pulce.wristglider"
-        myVersionCode=27
+        myVersionCode=28
         myVersionNumber="0.4.8"
         myMinSdkVersion=21
         myWearMinSdkVersion=23

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -23,6 +23,11 @@ public class Statics {
 
     public static final int MY_NULL_VALUE = -999999;
 
+    public static final float MY_LPF_ALPHA = 0.5f;
+
+    public static final double KF_VAR_ACCEL = 0.0075;  // Variance of pressure acceleration noise input.
+    public static final double KF_VAR_MEASUREMENT = 0.05;  // Variance of pressure measurement noise.
+
     private static final DecimalFormat latForm = new DecimalFormat("0000000");
     private static final DecimalFormat lonForm = new DecimalFormat("00000000");
 

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -27,8 +27,8 @@ public class Statics {
 
     public static final double KF_PRESSURE_VAR_ACCEL = 0.0075;  // Variance of pressure acceleration noise input.
     public static final double KF_PRESSURE_VAR_MEASUREMENT = 0.05;  // Variance of pressure measurement noise.
-    public static final double KF_ALT_VAR_ACCEL = 0.025;  // Variance of altitude acceleration noise input.
-    public static final double KF_ALT_VAR_MEASUREMENT = 0.001;  // Variance of altitude measurement noise.
+    public static final double KF_ALT_VAR_ACCEL = 0.01;  // Variance of altitude acceleration noise input.
+    public static final double KF_ALT_VAR_MEASUREMENT = 0.005;  // Variance of altitude measurement noise.
 
     public static final int MY_BEEP_DURATION = 200;
     public static final int MY_BEEP_DURATION_COEF = 70;

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -30,6 +30,13 @@ public class Statics {
     public static final double KF_ALT_VAR_ACCEL = 0.025;  // Variance of altitude acceleration noise input.
     public static final double KF_ALT_VAR_MEASUREMENT = 0.001;  // Variance of altitude measurement noise.
 
+    public static final int MY_BEEP_DURATION = 200;
+    public static final int MY_BEEP_DURATION_COEF = 70;
+    public static final int MY_UP_MAX_VARIO_THRESHOLD = 10;
+    public static final int MY_INITIAL_FREQ_UP = 1200;
+    public static final int MY_FREQ_COEF = 100;
+    public static final int MY_FREQ_DOWN = 800;
+
     private static final DecimalFormat latForm = new DecimalFormat("0000000");
     private static final DecimalFormat lonForm = new DecimalFormat("00000000");
 
@@ -53,7 +60,9 @@ public class Statics {
     public static final String PREFVARIOUNIT = "/com/pulce/wristglider/prefvariounit";
     public static final String PREFUSEBTVARIO = "/com/pulce/wristglider/prefusebtvario";
     public static final String PREFBTVARIODEVICE = "/com/pulce/wristglider/prefbtvariodevice";
-
+    public static final String PREFVARIOBEEPER = "/com/pulce/wristglider/prefvariobeeper";
+    public static final String PREFVARIOBEEPERDOWN = "/com/pulce/wristglider/prefvariobeeperdown";
+    public static final String PREFVARIOBEEPERUP = "/com/pulce/wristglider/prefvariobeeperup";
 
     public static String getUTCdateReverse() {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -43,8 +43,8 @@ public class Statics {
     public static final String PREFSCREENON = "/com/pulce/wristglider/prefscreenon";
     public static final String PREFHEIGTHUNIT = "/com/pulce/wristglider/prefheightunit";
     public static final String PREFSPEEDUNIT = "/com/pulce/wristglider/prefspeedunit";
+    public static final String PREFVARIOUNIT = "/com/pulce/wristglider/prefvariounit";
     public static final String PREFUSEBTVARIO = "/com/pulce/wristglider/prefusebtvario";
-    public static final String PREFBTVARIOUNIT = "/com/pulce/wristglider/prefbtvariounit";
     public static final String PREFBTVARIODEVICE = "/com/pulce/wristglider/prefbtvariodevice";
 
 

--- a/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
+++ b/commonclasses/src/main/java/com/pulce/commonclasses/Statics.java
@@ -23,10 +23,12 @@ public class Statics {
 
     public static final int MY_NULL_VALUE = -999999;
 
-    public static final float MY_LPF_ALPHA = 0.5f;
+    public static final float MY_LPF_ALPHA = 0.25f;
 
-    public static final double KF_VAR_ACCEL = 0.0075;  // Variance of pressure acceleration noise input.
-    public static final double KF_VAR_MEASUREMENT = 0.05;  // Variance of pressure measurement noise.
+    public static final double KF_PRESSURE_VAR_ACCEL = 0.0075;  // Variance of pressure acceleration noise input.
+    public static final double KF_PRESSURE_VAR_MEASUREMENT = 0.05;  // Variance of pressure measurement noise.
+    public static final double KF_ALT_VAR_ACCEL = 0.025;  // Variance of altitude acceleration noise input.
+    public static final double KF_ALT_VAR_MEASUREMENT = 0.001;  // Variance of altitude measurement noise.
 
     private static final DecimalFormat latForm = new DecimalFormat("0000000");
     private static final DecimalFormat lonForm = new DecimalFormat("00000000");

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -101,7 +101,7 @@ public class MainActivity extends Activity implements
         addTableRow(getString(R.string.height_unit), Statics.PREFHEIGTHUNIT);
         addTableRow(getString(R.string.speed_unit), Statics.PREFSPEEDUNIT);
         addTableRow(getString(R.string.use_bt_vario), Statics.PREFUSEBTVARIO);
-        addTableRow(getString(R.string.vario_unit), Statics.PREFBTVARIOUNIT);
+        addTableRow(getString(R.string.vario_unit), Statics.PREFVARIOUNIT);
 
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(this)
@@ -316,7 +316,7 @@ public class MainActivity extends Activity implements
         dataMap.getDataMap().putString(Statics.PREFHEIGTHUNIT, prefs.getString(Statics.PREFHEIGTHUNIT, "m"));
         dataMap.getDataMap().putString(Statics.PREFROTATEDEGREES, prefs.getString(Statics.PREFROTATEDEGREES, "0"));
         dataMap.getDataMap().putBoolean(Statics.PREFUSEBTVARIO, prefs.getBoolean(Statics.PREFUSEBTVARIO, false));
-        dataMap.getDataMap().putString(Statics.PREFBTVARIOUNIT, prefs.getString(Statics.PREFBTVARIOUNIT, "m/s"));
+        dataMap.getDataMap().putString(Statics.PREFVARIOUNIT, prefs.getString(Statics.PREFVARIOUNIT, "m/s"));
         PutDataRequest request = dataMap.asPutDataRequest();
         request.setUrgent();
         Wearable.DataApi.putDataItem(mGoogleApiClient, request);
@@ -500,7 +500,7 @@ public class MainActivity extends Activity implements
                 break;
             case Statics.PREFHEIGTHUNIT:
             case Statics.PREFSPEEDUNIT:
-            case Statics.PREFBTVARIOUNIT:
+            case Statics.PREFVARIOUNIT:
             case Statics.PREFLOGGERSECONDS:
             case Statics.PREFROTATEDEGREES:
                 final Spinner spinner2 = new Spinner(this);
@@ -521,7 +521,7 @@ public class MainActivity extends Activity implements
                         spinner2Array.add("mph");
                         spinner2Array.add("kn");
                         break;
-                    case Statics.PREFBTVARIOUNIT:
+                    case Statics.PREFVARIOUNIT:
                         spinner2Array.add("m/s");
                         spinner2Array.add("kn");
                         break;

--- a/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
+++ b/mobile/src/main/java/com/pulce/wristglider/MainActivity.java
@@ -17,6 +17,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -577,21 +578,21 @@ public class MainActivity extends Activity implements
                 final TextView tv = new TextView(this);
                 final SeekBar sb = new SeekBar(this);
                 sb.setLayoutParams(new TableRow.LayoutParams(TableRow.LayoutParams.MATCH_PARENT, TableRow.LayoutParams.WRAP_CONTENT));
-                sb.setMax(200); // -100 to 100
-                sb.setProgress((int) (100 + prefs.getFloat(preferencekey, 0) * 10)); // float to int with shift (ex. 1,5 as 115) )
-                tv.setText(String.format("%.1f", (sb.getProgress() - 100) / 10.f)); // int to float with shift (ex. 115 as 1,5)
+                sb.setMax(100); // -50 to 50
+                sb.setProgress((int) (50 + prefs.getFloat(preferencekey, 0) * 10)); // float to int with shift (ex. 1,5 as 65) )
+                tv.setText(String.format("%.1f", (sb.getProgress() - 50) / 10.f)); // int to float with shift (ex. 65 as 1,5)
                 sb.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
                     int pval = 0;
                     @Override
                     public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                         pval = progress;
-                        tv.setText(String.format("%.1f", (progress - 100) / 10.f)); // int to float with shift (ex. 115 as 1,5)
+                        tv.setText(String.format("%.1f", (progress - 50) / 10.f)); // int to float with shift (ex. 65 as 1,5)
                     }
                     @Override
                     public void onStartTrackingTouch(SeekBar seekBar) {}
                     @Override
                     public void onStopTrackingTouch(SeekBar seekBar) {
-                        prefs.edit().putFloat(preferencekey, (pval - 100) / 10.f).apply(); // int to float with shift (ex. 115 as 1,5)
+                        prefs.edit().putFloat(preferencekey, (pval - 50) / 10.f).apply(); // int to float with shift (ex. 65 as 1,5)
                         updatePreferences();
                     }
                 });
@@ -653,7 +654,8 @@ public class MainActivity extends Activity implements
                 });
                 break;
         }
-        tablelayout.addView(tr, new TableLayout.LayoutParams(TableLayout.LayoutParams.MATCH_PARENT, TableLayout.LayoutParams.WRAP_CONTENT));
+        tr.setGravity(Gravity.CENTER_VERTICAL);
+        tablelayout.addView(tr);
     }
 
     @Override

--- a/mobile/src/main/res/layout/spinner_item_two_boxes.xml
+++ b/mobile/src/main/res/layout/spinner_item_two_boxes.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
     <TextView xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/spinner_twoline_text_view"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:paddingTop="20px"
-        android:paddingBottom="20px"
-        android:paddingStart="15px"
-        android:paddingEnd="15px"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
         android:maxLines="2"
         android:textAppearance="@android:style/TextAppearance.Material.Medium"
         />

--- a/mobile/src/main/res/layout/standard_textview.xml
+++ b/mobile/src/main/res/layout/standard_textview.xml
@@ -3,9 +3,9 @@
     android:id="@+id/standard_text_view"
     android:layout_height="wrap_content"
     android:layout_width="wrap_content"
-    android:paddingTop="20px"
-    android:paddingBottom="20px"
-    android:paddingStart="15px"
-    android:paddingEnd="15px"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:paddingStart="10dp"
+    android:paddingEnd="10dp"
     android:textAppearance="@android:style/TextAppearance.Material.Medium"
     />

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -25,4 +25,7 @@
     <string name="bt_failed_user">Bluetooth Verbindung von Benutzer getrennt</string>
     <string name="vario_unit">Einheit Vario</string>
     <string name="new_glider_fail_no_type">Fluggerät Typ muss angegeben werden</string>
+    <string name="vario_beeper">Vario piepser</string>
+    <string name="vario_beeper_down">Senkenschwelle</string>
+    <string name="vario_beeper_up">Hubschwelle</string>
 </resources>

--- a/mobile/src/main/res/values-pl/strings.xml
+++ b/mobile/src/main/res/values-pl/strings.xml
@@ -25,4 +25,7 @@
     <string name="bt_failed_user">Połączenie Bluetooth anulowane przez użytkownika</string>
     <string name="vario_unit">Wariometr</string>
     <string name="new_glider_fail_no_type">Typ paralotni nie może być pusty.</string>
+    <string name="vario_beeper">Dźwięk vario</string>
+    <string name="vario_beeper_up">Wznoszenie od</string>
+    <string name="vario_beeper_down">Opadanie od</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -23,5 +23,8 @@
     <string name="bt_failed_no_device">Bluetooth Vario device not found</string>
     <string name="bt_failed_user">Bluetooth connection canceled by the user</string>
     <string name="vario_unit">Vario unit</string>
+    <string name="vario_beeper">Vario beeper</string>
+    <string name="vario_beeper_up">Lift threshold</string>
+    <string name="vario_beeper_down">Sink threshold</string>
     <string name="new_glider_fail_no_type">Glider type cannot be empty.</string>
 </resources>

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.myCompileSdkVersion.toInteger()
-    publishNonDefault true
 
     defaultConfig {
         applicationId project.ext.myApplicationID

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -47,5 +47,6 @@ dependencies {
     compileOnly 'com.google.android.wearable:wearable:2.4.0'
     implementation 'com.google.firebase:firebase-appindexing:11.6.2'
     implementation 'com.google.android.gms:play-services-location:11.6.2'
+    implementation 'com.github.karlotoy:perfectTune:1.0.2'
     implementation project(':commonclasses')
 }

--- a/wear/src/main/java/com/pulce/wristglider/Beeper.java
+++ b/wear/src/main/java/com/pulce/wristglider/Beeper.java
@@ -1,0 +1,59 @@
+package com.pulce.wristglider;
+
+import com.karlotoy.perfectune.instance.PerfectTune;
+import com.pulce.commonclasses.Statics;
+
+public class Beeper {
+
+    private PerfectTune tone;
+    private long lastTime;
+    private static int BeepDuration = Statics.MY_BEEP_DURATION;
+    private static int BeepDurationCoef = Statics.MY_BEEP_DURATION_COEF;
+    private static int UpMaxVarioThreshold = Statics.MY_UP_MAX_VARIO_THRESHOLD;
+    private static int InitialFreqUp = Statics.MY_INITIAL_FREQ_UP;
+    private static int FreqCoef = Statics.MY_FREQ_COEF;
+    private static int FreqDown = Statics.MY_FREQ_DOWN;
+    private boolean playFlag = true;
+
+    private float upVarioThreshold = 0;
+    private float downVarioThreshold = -2;
+
+    Beeper(float varioThresholdUp, float varioThresholdDown) {
+        tone = new PerfectTune();
+        lastTime = System.currentTimeMillis();
+        setThresholds(varioThresholdUp, varioThresholdDown);
+    }
+
+    public void setThresholds(float varioThresholdUp, float varioThresholdDown) {
+        upVarioThreshold = varioThresholdUp;
+        downVarioThreshold = varioThresholdDown;
+    }
+
+    public void beep(float vario) {
+        float duration = (BeepDuration - vario * BeepDurationCoef >= 25) ? BeepDuration - vario * BeepDurationCoef : 25;
+        if (System.currentTimeMillis() - lastTime > duration && !playFlag) {
+            playFlag = !playFlag;
+            tone.stopTune();
+        }
+        if (vario > UpMaxVarioThreshold) vario = UpMaxVarioThreshold; // cut-off to max UpMaxVarioThreshold (default 10m/s)
+
+        if (vario > upVarioThreshold) {
+            duration = duration * 3;
+            if (playFlag && ((System.currentTimeMillis() - lastTime) > duration)) {
+                lastTime = System.currentTimeMillis();
+                tone.setTuneFreq(InitialFreqUp + vario * FreqCoef);
+                tone.playTune();
+                playFlag = !playFlag;
+            }
+        } else if (vario < downVarioThreshold) {
+            tone.setTuneFreq(FreqDown);
+            tone.playTune();
+        } else {
+            tone.stopTune();
+        }
+    }
+
+    public void stop() {
+        tone.stopTune();
+    }
+}

--- a/wear/src/main/java/com/pulce/wristglider/KalmanFilter.java
+++ b/wear/src/main/java/com/pulce/wristglider/KalmanFilter.java
@@ -1,0 +1,113 @@
+package com.pulce.wristglider;
+
+public class KalmanFilter {
+    // The state we are tracking, namely:
+    private double x_abs_;  // The absolute value of x.
+    private double x_vel_;  // The rate of change of x.
+
+    // Covariance matrix for the state.
+    private double p_abs_abs_;
+    private double p_abs_vel_;
+    private double p_vel_vel_;
+
+    // The variance of the acceleration noise input in the system model.
+    private double var_accel_;
+
+    // Constructor. Assumes a variance of 1.0 for the system model's
+    // acceleration noise input, in units per second squared.
+    public KalmanFilter() {
+        setAccelerationVariance(1.);
+        reset();
+    }
+
+    // Constructor. Caller supplies the variance for the system model's
+    // acceleration noise input, in units per second squared.
+    public KalmanFilter(double var_accel) {
+        setAccelerationVariance(var_accel);
+        reset();
+    }
+
+    // The following three methods reset the filter. All of them assign a huge
+    // variance to the tracked absolute quantity and a var_accel_ variance to
+    // its derivative, so the very next measurement will essentially be
+    // copied directly into the filter. Still, we provide methods that allow
+    // you to specify initial settings for the filter's tracked state.
+
+    public void reset() {
+        reset(0., 0.);
+    }
+
+    public void reset(double abs_value) {
+        reset(abs_value, 0.);
+    }
+
+    public void reset(double abs_value, double vel_value) {
+        x_abs_ = abs_value;
+        x_vel_ = vel_value;
+        p_abs_abs_ = 1.e6;
+        p_abs_vel_ = 0.;
+        p_vel_vel_ = var_accel_;
+    }
+
+    // Sets the variance for the acceleration noise input in the system model,
+    // in units per second squared.
+    public void setAccelerationVariance(double var_accel) {
+        var_accel_ = var_accel;
+    }
+
+    // Updates state given a sensor measurement of the absolute value of x,
+    // the variance of that measurement, and the interval since the last
+    // measurement in seconds. This interval must be greater than 0; for the
+    // first measurement after a reset(), it's safe to use 1.0.
+    public void update(double z_abs, double var_z_abs, double dt) {
+        // Note: math is not optimized by hand. Let the compiler sort it out.
+        // Predict step.
+        // Update state estimate.
+        x_abs_ += x_vel_ * dt;
+		/*// Update state covariance. The last term mixes in acceleration noise.
+		p_abs_abs_ += 2.*dt*p_abs_vel_ + dt*dt*p_vel_vel_ + var_accel_*dt*dt*dt*dt/4.;
+		p_abs_vel_ +=                       dt*p_vel_vel_ + var_accel_*dt*dt*dt/2.;
+		p_vel_vel_ +=                                     + var_accel_*dt*dt;
+
+		// Update step.
+		double y = z_abs - x_abs_;  // Innovation.
+		double s_inv = 1. / (p_abs_abs_ + var_z_abs);  // Innovation precision.
+		double k_abs = p_abs_abs_*s_inv;  // Kalman gain
+		double k_vel = p_abs_vel_*s_inv;
+		// Update state estimate.
+		x_abs_ += k_abs * y;
+		x_vel_ += k_vel * y;
+		// Update state covariance.
+		p_vel_vel_ -= p_abs_vel_*k_vel;
+		p_abs_vel_ -= p_abs_vel_*k_abs;
+		p_abs_abs_ -= p_abs_abs_*k_abs;*/
+
+        // Update state covariance. The last term mixes in acceleration noise.
+        double dt2 = Math.pow(dt,2);
+        double dt3 = dt * dt2;
+        double dt4 = Math.pow(dt2,2);
+        p_abs_abs_ += 2 * dt * p_abs_vel_ + dt2 * p_vel_vel_ + var_accel_ * dt4 / 4;
+        p_abs_vel_ += dt * p_vel_vel_ + var_accel_ * dt3 / 2;
+        p_vel_vel_ += var_accel_ * dt2;
+
+        // Update step.
+        double y = z_abs - x_abs_;  // Innovation.
+        double s_inv = 1. / (p_abs_abs_ + var_z_abs);  // Innovation precision.
+        double k_abs = p_abs_abs_*s_inv;  // Kalman gain
+        double k_vel = p_abs_vel_*s_inv;
+        // Update state estimate.
+        x_abs_ += k_abs * y;
+        x_vel_ += k_vel * y;
+        // Update state covariance.
+        p_vel_vel_ -= p_abs_vel_*k_vel;
+        p_abs_vel_ -= p_abs_vel_*k_abs;
+        p_abs_abs_ -= p_abs_abs_*k_abs;
+    }
+
+    // Getters for the state and its covariance.
+    public double getXAbs() { return x_abs_; }
+    public double getXVel() { return x_vel_; }
+    public double getCovAbsAbs() { return p_abs_abs_; }
+    public double getCovAbsVel() { return p_abs_vel_; }
+    public double getCovVelVel() { return p_vel_vel_; }
+}

--- a/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
+++ b/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
@@ -725,13 +725,11 @@ public class MainWearActivity extends WearableActivity implements
     @Override
     public final void onAccuracyChanged(Sensor sensor, int accuracy) {
         // Do something here if sensor accuracy changes.
-        if (debugMode) Log.d(TAG, String.format("Pressure accuracy changed: %d", accuracy));
     }
 
     @Override
     public final void onSensorChanged(SensorEvent event) {
         final float pressure_hPa = event.values[0];
-        if (debugMode) Log.d(TAG, String.format("Pressure changed: %.2f", pressure_hPa));
 
         final double currMeasurementTime = SystemClock.elapsedRealtime() / 1000.0f;
         final double dt = currMeasurementTime - lastMeasurementTime;
@@ -748,7 +746,7 @@ public class MainWearActivity extends WearableActivity implements
             mVarioData.baroAlt = Math.round(baroAltitude);
             mVarioData.vario = (float) altitudeFilter.getXVel();
 
-            if (debugMode) Log.d(TAG, String.format("Pressure filtered: %.2f, baroalt: %d, vario: %.2f", mVarioData.pressure, mVarioData.baroAlt, mVarioData.vario));
+            //if (debugMode) Log.d(TAG, String.format("Pressure filtered: %.2f, baroalt: %d, vario: %.2f", mVarioData.pressure, mVarioData.baroAlt, mVarioData.vario));
         } else {
             mVarioData.pressure = pressure_hPa;
             mVarioData.baroAlt = Math.round(SensorManager.getAltitude(SensorManager.PRESSURE_STANDARD_ATMOSPHERE, mVarioData.pressure));
@@ -779,7 +777,7 @@ public class MainWearActivity extends WearableActivity implements
 
             lastMeasurementTime = SystemClock.elapsedRealtime() / 1000.0f;
 
-            sensorManager.registerListener(this, pressure, SensorManager.SENSOR_DELAY_NORMAL);
+            sensorManager.registerListener(this, pressure, SensorManager.SENSOR_DELAY_FASTEST);
             switchView(stdViewVario);
         }
     }
@@ -792,7 +790,7 @@ public class MainWearActivity extends WearableActivity implements
 
     @Override
     public void onLocationChanged(Location location) {
-        if (debugMode) Log.d(TAG, "location changed");
+        //if (debugMode) Log.d(TAG, "location changed");
         killFirstDirtylocations++;
         if (location.hasSpeed()) {
             speedTextView.setText(String.format("%.1f", location.getSpeed() * speedmultiplier));

--- a/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
+++ b/wear/src/main/java/com/pulce/wristglider/MainWearActivity.java
@@ -120,6 +120,8 @@ public class MainWearActivity extends WearableActivity implements
     private View[] varioBarPos = new View[10];
     private View[] varioBarNeg = new View[10];
 
+    private Beeper beeper;
+
     private Bitmap arrowBitmap;
     private Bitmap arrowStartBitmap;
     private Matrix rotateMatrix = new Matrix();
@@ -319,6 +321,8 @@ public class MainWearActivity extends WearableActivity implements
             if (debugMode) Log.d(TAG, "No barometer");
         }
 
+        beeper = new Beeper(prefs.getFloat(Statics.PREFVARIOBEEPERUP, 0), prefs.getFloat(Statics.PREFVARIOBEEPERDOWN, -2));
+
         if (mockup) {
             progressBar.setVisibility(View.INVISIBLE);
             speedTextView.setText("36.5");
@@ -394,6 +398,7 @@ public class MainWearActivity extends WearableActivity implements
         mGoogleApiClient.disconnect();
         mHandler.removeCallbacksAndMessages(null);
         disableBTConnection();
+        beeper.stop();
     }
 
     @Override
@@ -407,6 +412,7 @@ public class MainWearActivity extends WearableActivity implements
                     .removeLocationUpdates(mGoogleApiClient, this);
         }
         mGoogleApiClient.disconnect();
+        beeper.stop();
     }
 
     @Override
@@ -718,6 +724,16 @@ public class MainWearActivity extends WearableActivity implements
                 sendBTFailed(Statics.MY_BT_FAILED_NO_BT);
             }
         }
+        if (prefs.getBoolean(Statics.PREFVARIOBEEPER, false) != dataMapItem.getDataMap().getBoolean(Statics.PREFVARIOBEEPER)) {
+            if (!dataMapItem.getDataMap().getBoolean(Statics.PREFVARIOBEEPER, false)) {
+                beeper.stop();
+            }
+        }
+        prefs.edit().putBoolean(Statics.PREFVARIOBEEPER, dataMapItem.getDataMap().getBoolean(Statics.PREFVARIOBEEPER)).apply();
+        prefs.edit().putFloat(Statics.PREFVARIOBEEPERUP, dataMapItem.getDataMap().getFloat(Statics.PREFVARIOBEEPERUP)).apply();
+        prefs.edit().putFloat(Statics.PREFVARIOBEEPERDOWN, dataMapItem.getDataMap().getFloat(Statics.PREFVARIOBEEPERDOWN)).apply();
+
+        beeper.setThresholds(prefs.getFloat(Statics.PREFVARIOBEEPERUP, 0), prefs.getFloat(Statics.PREFVARIOBEEPERDOWN, -2));
         setMultipliers();
         if (debugMode) Log.d(TAG, "Preferences updated");
     }
@@ -1195,6 +1211,9 @@ public class MainWearActivity extends WearableActivity implements
                 for (View varBar : varioBarNeg) {
                     varBar.setVisibility(View.INVISIBLE);
                 }
+            }
+            if (prefs.getBoolean(Statics.PREFVARIOBEEPER, false)) {
+                beeper.beep(mVarioData.vario);
             }
         }
         else {

--- a/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
+++ b/wear/src/main/res/layout-notround/activity_wear_main_vario.xml
@@ -325,7 +325,6 @@
                     android:layout_height="58dp"
                     android:layout_alignParentStart="true"
                     android:layout_alignParentTop="true"
-                    android:layout_marginStart="5dp"
                     android:layout_marginTop="5dp"
                     android:layout_centerVertical="true">
 


### PR DESCRIPTION
Hi, this time I've added support for watch built-in barometric sensor. It works interchangeably with BT vario. Jut if barometric sensor is present - it will enable vario view. When user choose to use BT vario - internal sensor will be ignored.

https://youtu.be/sIB_VGjLi9Y

I've also added vario beeper - it is disabled by default. User in companion app can enable beeper sound and set thresholds for sink and lift rates.

https://www.youtube.com/watch?v=jFrryPLuaRs

Internal barometric sensor is parsed to Kalman filter. Blue dots are raw sensor pressure, red are after Kalman filter, yellow is drawed manually mor eor less real move

![Pressure raw data](https://i.ibb.co/3mqgtvc/image.png)

Vertical speed is also filtered. Colors means the same as before.

![Vario raw data](https://i.ibb.co/gtVk7Yz/image.png)

Please check german translations for new options - I've used google translator ;)
